### PR TITLE
Where possible use Input.GetButtonOrigin() for input descriptions

### DIFF
--- a/code/tools/Debugger.cs
+++ b/code/tools/Debugger.cs
@@ -64,10 +64,10 @@ namespace Sandbox.Tools
 		{
 			if ( Game.IsClient )
 			{
-				Description = "Shows selected wire ports on the HUD.\nShift-F for Wiring tool.\n";
-				Description += "\nPrimary: Add entity to HUD";
-				Description += "\nSecondary: Remove entity from HUD";
-				Description += "\nReload: Clear HUD";
+				Description = $"Shows selected wire ports on the HUD.\n{Input.GetButtonOrigin( "run" )} - {Input.GetButtonOrigin( "flashlight" )} for Wiring tool.\n";
+				Description += $"\n{Input.GetButtonOrigin( "attack1" )}: Add entity to HUD";
+				Description += $"\n{Input.GetButtonOrigin( "attack2" )}: Remove entity from HUD";
+				Description += $"\n{Input.GetButtonOrigin( "reload" )}: Clear HUD";
 
 				SandboxHud.Instance.RootPanel.ChildrenOfType<DebuggerHud>().ToList().ForEach( x => x.Delete() );
 				debuggerHud = SandboxHud.Instance.RootPanel.AddChild<DebuggerHud>();

--- a/code/tools/Wiring.cs
+++ b/code/tools/Wiring.cs
@@ -224,20 +224,20 @@ namespace Sandbox.Tools
 
 		private string CalculateDescription()
 		{
-			var desc = $"Connect wirable entities with wires.\nHold G to spawn Gates.\nShift-F for Debugger.\n";
+			var desc = $"Connect wirable entities with wires.\nHold G to spawn Gates.\n{Input.GetButtonOrigin( "run" )} - {Input.GetButtonOrigin( "flashlight" )} for Debugger.\n";
 			if ( Stage == 0 )
 			{
-				desc += "\nPrimary: select Input";
-				desc += "\nSecondary: scroll to next Input (shift for previous)";
+				desc += $"\n{Input.GetButtonOrigin( "attack1" )}: select Input";
+				desc += $"\n{Input.GetButtonOrigin( "attack2" )}: scroll to next Input ({Input.GetButtonOrigin( "run" )} for previous)";
 				desc += "\nScroll Wheel: scroll between Inputs";
-				desc += "\nReload: Disconnect Input";
+				desc += $"\n{Input.GetButtonOrigin( "reload" )}: Disconnect Input";
 			}
 			else if ( Stage == 1 )
 			{
-				desc += "\nPrimary: select Output";
-				desc += "\nSecondary: scroll to next Output (shift for previous)";
+				desc += $"\n{Input.GetButtonOrigin( "attack1" )}: select Output";
+				desc += $"\n{Input.GetButtonOrigin( "attack2" )}: scroll to next Output ({Input.GetButtonOrigin( "run" )} for previous)";
 				desc += "\nScroll Wheel: scroll between Outputs";
-				desc += "\nReload: Cancel";
+				desc += $"\n{Input.GetButtonOrigin( "reload" )}: Cancel";
 			}
 			return desc;
 		}

--- a/code/tools/Wiring.cs
+++ b/code/tools/Wiring.cs
@@ -224,7 +224,8 @@ namespace Sandbox.Tools
 
 		private string CalculateDescription()
 		{
-			var desc = $"Connect wirable entities with wires.\nHold G to spawn Gates.\n{Input.GetButtonOrigin( "run" )} - {Input.GetButtonOrigin( "flashlight" )} for Debugger.\n";
+			var drop = Input.GetButtonOrigin( "drop", true ) == null ? Input.GetButtonOrigin( "drop" ) : "G";
+			var desc = $"Connect wirable entities with wires.\nHold {drop} to spawn Gates.\n{Input.GetButtonOrigin( "run" )} - {Input.GetButtonOrigin( "flashlight" )} for Debugger.\n";
 			if ( Stage == 0 )
 			{
 				desc += $"\n{Input.GetButtonOrigin( "attack1" )}: select Input";


### PR DESCRIPTION
This changes the onscreen descriptions currently in use for the wiretools with controls listed to use what is assigned for the actions, so that for example "R: Disconnect Input" would become "T: Disconnect Input" if I was to change my reload key to T.

Plus the added benefit of supporting listing Controller inputs.

There are some issues with this, there is no current way as far as I can tell to indicate for scroll wheel input.
Additionally it just throws errors when using a controller if there is no controller binding for an action, for example, the Drop action has no binding so changing "Hold G to Spawn Gates" to "Hold {Input.GetButtonOrigin("drop")} to Spawn Gates" is not as simple.

It would require changing the tool description UI in SandboxPlus but ideally we would also show a buttons glyph.