### PR TITLE
Added memory gates for handling state

### DIFF
--- a/code/entities/WireGateEntity.cs
+++ b/code/entities/WireGateEntity.cs
@@ -22,7 +22,7 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 	{
 		return new Dictionary<string, string[]>
 		{
-			["Math"] = new string[] { "Constant", "Add", "Subtract", "Multiply", "Divide", "Negate", "Absolute", "Sin", "Cos" },
+			["Math"] = new string[] { "Constant", "Add", "Subtract", "Multiply", "Divide", "Mod", "Negate", "Absolute", "Sin", "Cos" },
 			["Logic"] = new string[] { "Not", "And", "Or", "GreaterThan", "LessThan", "Equal" },
 			["Comparison"] = new string[] { "Max", "Min", "Clamp" },
 			["Time"] = new string[] { "Delta", "Tick", "Smoother" },
@@ -155,6 +155,21 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 				else
 				{
 					this.WireTriggerOutput( "Out", inputs["A"].asFloat / b );
+				}
+			}, new string[] { "A", "B" } );
+		}
+		else if ( GateType == "Mod" )
+		{
+			BulkRegisterInputHandlers( ( float value ) =>
+			{
+				var b = inputs["B"].asFloat;
+				if ( b == 0 )
+				{
+					this.WireTriggerOutput( "Out", 0 );
+				}
+				else
+				{
+					this.WireTriggerOutput( "Out", inputs["A"].asFloat % b );
 				}
 			}, new string[] { "A", "B" } );
 		}

--- a/code/entities/WireGateEntity.cs
+++ b/code/entities/WireGateEntity.cs
@@ -356,7 +356,7 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 		else if ( GateType == "Latch" )
 		{
 			this.RegisterInputHandler( "Value", (float value) => { });
-			this.RegisterInputHandler( "Clk", ( bool value ) =>
+			this.RegisterInputHandler( "Write", ( bool value ) =>
 			{
 				if ( value )
 				{
@@ -397,7 +397,7 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 				}
 			} );
 			this.RegisterInputHandler( "Value", ( float value ) => { } );
-			this.RegisterInputHandler( "Clk", ( bool value ) =>
+			this.RegisterInputHandler( "Write", ( bool value ) =>
 			{
 				var address = (int)inputs["Address"].asFloat;
 				if ( value && address is >= 0 and < 32768 )

--- a/code/entities/WireGateEntity.cs
+++ b/code/entities/WireGateEntity.cs
@@ -27,6 +27,7 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 			["Comparison"] = new string[] { "Max", "Min", "Clamp" },
 			["Time"] = new string[] { "Delta", "Tick", "Smoother" },
 			["Entity"] = new string[] { "Position", "Velocity", "Owner" },
+			["Memory"] = new string[] { "Latch", "D-Latch", "Toggle", "RAM", "Incrementor" },
 		};
 	}
 
@@ -349,6 +350,66 @@ public partial class WireGateEntity : Prop, IWireInputEntity, IWireOutputEntity,
 			this.RegisterInputHandler( "Ent", ( Entity value ) =>
 			{
 				storedEnt = value;
+			} );
+		}
+		else if ( GateType == "Latch" )
+		{
+			this.RegisterInputHandler( "Value", (float value) => { });
+			this.RegisterInputHandler( "Clk", ( bool value ) =>
+			{
+				if ( value )
+				{
+					this.WireTriggerOutput( "Out", inputs["Value"].asFloat );
+				}
+			} );
+		}
+		else if ( GateType == "D-Latch" )
+		{
+			BulkRegisterInputHandlers( ( float value ) =>
+			{
+				if ( inputs["On"].asBool )
+				{
+					this.WireTriggerOutput( "Out", inputs["Value"].asFloat );
+				}
+			}, new string[] { "Value", "On" } );
+		}
+		else if ( GateType == "Toggle" )
+		{
+			this.RegisterInputHandler( "Toggle", ( bool value ) =>
+			{
+				if ( value )
+				{
+					float newValue = Math.Abs( storedFloat - 1 ) < 0.01 ? 0 : 1;
+					storedFloat = newValue;
+					this.WireTriggerOutput( "Out", newValue );
+				}
+			} );
+		}
+		else if ( GateType == "Incrementor" )
+		{
+			this.RegisterInputHandler( "Increment", ( bool value ) =>
+			{
+				if ( value )
+				{
+					storedFloat++;
+					this.WireTriggerOutput( "Out", storedFloat );
+				}
+			} );
+			this.RegisterInputHandler( "Decrement", ( bool value ) =>
+			{
+				if ( value )
+				{
+					storedFloat--;
+					this.WireTriggerOutput( "Out", storedFloat );
+				}
+			} );
+			this.RegisterInputHandler( "Reset", ( bool value ) =>
+			{
+				if ( value )
+				{
+					storedFloat = 0;
+					this.WireTriggerOutput( "Out", storedFloat );
+				}
 			} );
 		}
 	}


### PR DESCRIPTION
You may want to change some of the names of the inputs to the gates to your liking as well as maybe renaming the D-Latch to something else, unless we do that at a later date when we come up with something.

Slightly strange behaviour due to getting a fire on bool input every time the value is changed even if something is true, meaning that edge triggered things trigger on everything other than 0.

A temporary fix could be done inside of the gates or it could be left as it is and the boolean inputs be changed if that is not what we want to happen.